### PR TITLE
change CI pipeline from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: "0 23 * * 6"
 
 jobs:
   build:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -1,0 +1,26 @@
+name: Crystal CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: crystallang/crystal
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: shards install
+      - name: Run tests
+        run: crystal spec
+      - name: Check formatting
+        run: crystal tool format --check
+      - name: Lint
+        run: bin/ameba

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-
-script:
-  - crystal spec
-  - crystal tool format --check
-  - bin/ameba

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Four Squares
 
+[![Crystal CI](https://github.com/c910335/four-squares/actions/workflows/crystal.yml/badge.svg)](https://github.com/c910335/four-squares/actions/workflows/crystal.yml)
+
 A deterministic polynomial-time algorithm for finding a representation of a prime as a sum of four squares
 
 ## Installation

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ targets:
   four_squares:
     main: src/four_squares.cr
 
-crystal: 0.36.1
+crystal: 1.0.0
 
 license: MIT
 


### PR DESCRIPTION
1. Change CI pipeline from Travis to GitHub Actions.
2. Set CI status badge in README.md.
3. Update Crystal version to `1.0.0`.